### PR TITLE
Add support for per-application default modes per priority

### DIFF
--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -303,6 +303,26 @@ CREATE TABLE `target_application_mode` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `target_default_application_mode`
+--
+
+DROP TABLE IF EXISTS `default_application_mode`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `default_application_mode` (
+  `application_id` int(11) NOT NULL,
+  `priority_id` int(11) NOT NULL,
+  `mode_id` int(11) NOT NULL,
+  PRIMARY KEY (`mode_id`,`application_id`,`priority_id`),
+  KEY `default_application_mode_ibfk_1` (`application_id`),
+  KEY `default_application_mode_ibfk_2` (`priority_id`),
+  KEY `default_application_mode_ibfk_3` (`mode_id`),
+  CONSTRAINT `default_application_mode_ibfk_1` FOREIGN KEY (`application_id`) REFERENCES `application` (`id`),
+  CONSTRAINT `default_application_mode_ibfk_2` FOREIGN KEY (`priority_id`) REFERENCES `priority` (`id`),
+  CONSTRAINT `default_application_mode_ibfk_3` FOREIGN KEY (`mode_id`) REFERENCES `mode` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
 -- Table structure for table `target_contact`
 --
 

--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -390,6 +390,14 @@ JOIN `target` on `target`.`id` =  `target_application_mode`.`target_id`
 JOIN `application` on `application`.`id` = `target_application_mode`.`application_id`
 WHERE `target`.`name` = :username AND `application`.`name` = :app'''
 
+get_default_application_modes_query = '''
+SELECT `priority`.`name` as priority, `mode`.`name` as mode
+FROM `default_application_mode`
+JOIN `mode`  on `mode`.`id` = `default_application_mode`.`mode_id`
+JOIN `priority` on `priority`.`id` = `default_application_mode`.`priority_id`
+JOIN `application` on `application`.`id` = `default_application_mode`.`application_id`
+WHERE `application`.`name` = %s'''
+
 insert_user_modes_query = '''INSERT
 INTO `target_mode` (`priority_id`, `target_id`, `mode_id`)
 VALUES (
@@ -1387,6 +1395,10 @@ class Application(object):
             app['variables'].append(row['name'])
             if row['required']:
                 app['required_variables'].append(row['name'])
+
+        cursor.execute(get_default_application_modes_query, app_name)
+        app['default_modes'] = {row['priority']: row['mode'] for row in cursor}
+
         cursor.close()
         connection.close()
 


### PR DESCRIPTION
- Create new table to facilitate these default settings
- Add "default_modes" dict to application endpoint so we can see what the defaults are
  per app in the UI (once the UI exists)
- Make the set target contact query use dictionary interpolation to
  improve readability