### PR TITLE
Add per_app_modes key to user settings endpoint

### DIFF
--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1303,6 +1303,7 @@ def test_get_user(sample_user, sample_email):
     assert data['name'] == sample_user
     assert 'teams' in data
     assert 'modes' in data
+    assert 'per_app_modes' in data
 
 
 def test_healthcheck():


### PR DESCRIPTION
This way we can see all of our custom settings per app, instead
of having to execute one call per app that exists to get them all