### PR TITLE
Use underscores not dashes for quota_breach context variable

### DIFF
--- a/src/iris_api/sender/quota.py
+++ b/src/iris_api/sender/quota.py
@@ -159,7 +159,7 @@ class ApplicationQuota(object):
           'created': datetime.utcnow(),
           'sender_app_id': self.iris_application['id'],
           'context': ujson.dumps({
-            'quota-breach': {
+            'quota_breach': {
               'application': application,
               'limit': limit,
               'duration': duration


### PR DESCRIPTION
Because jinja doesn't like dashes in variable names apparently