### PR TITLE
Add support for dropping messages.

### DIFF
--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -1,5 +1,5 @@
 LOCK TABLES `mode` WRITE;
-INSERT INTO `mode` VALUES (26,'call'),(35,'email'),(17,'im'),(8,'sms');
+INSERT INTO `mode` VALUES (26,'call'),(35,'email'),(17,'im'),(8,'sms'),(36,'drop');
 UNLOCK TABLES;
 
 LOCK TABLES `priority` WRITE;
@@ -92,3 +92,5 @@ UNLOCK TABLES;
 
 LOCK TABLES `user_team` WRITE;
 UNLOCK TABLES;
+
+INSERT IGNORE INTO `application_mode` (`application_id`, `mode_id`) SELECT `application`.`id`, `mode`.`id` FROM `application`, `mode` WHERE `mode`.`name` != 'drop';

--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -578,15 +578,29 @@ CREATE TABLE `application_quota` (
   `soft_quota_threshold` smallint(5) NOT NULL,
   `hard_quota_duration` smallint(5) NOT NULL,
   `soft_quota_duration` smallint(5) NOT NULL,
-  `plan_name` varchar(255) NOT NULL,
-  `target_id` bigint(20) NOT NULL,
+  `plan_name` varchar(255),
+  `target_id` bigint(20),
   `wait_time` smallint(5) NOT NULL DEFAULT 0,
   PRIMARY KEY (`application_id`),
   KEY `application_quota_plan_name_fk_idx` (`plan_name`),
   KEY `application_quota_target_id_fk_idx` (`target_id`),
   CONSTRAINT `application_id_ibfk` FOREIGN KEY (`application_id`) REFERENCES `application` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `plan_name_ibfk` FOREIGN KEY (`plan_name`) REFERENCES `plan_active` (`name`) ON DELETE NO ACTION ON UPDATE CASCADE,
-  CONSTRAINT `target_id_ibfk` FOREIGN KEY (`target_id`) REFERENCES `target` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+  CONSTRAINT `plan_name_ibfk` FOREIGN KEY (`plan_name`) REFERENCES `plan_active` (`name`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `target_id_ibfk` FOREIGN KEY (`target_id`) REFERENCES `target` (`id`) ON DELETE SET NULL ON UPDATE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+
+--
+-- Table structure for table `application_mode`
+--
+
+DROP TABLE IF EXISTS `application_mode`;
+CREATE TABLE `application_mode` (
+  `application_id` int(11) NOT NULL,
+  `mode_id` int(11) NOT NULL,
+  PRIMARY KEY (`application_id`, `mode_id`),
+  CONSTRAINT `application_mode_application_id_ibfk` FOREIGN KEY (`application_id`) REFERENCES `application` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `application_mode_mode_id_ibfk` FOREIGN KEY (`mode_id`) REFERENCES `mode` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 

--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -32,7 +32,7 @@ from iris_api.sender.quota import get_application_quotas_query
 
 
 from .constants import (
-    XFRAME, XCONTENTTYPEOPTIONS, XXSSPROTECTION, MODE_DROP
+    XFRAME, XCONTENTTYPEOPTIONS, XXSSPROTECTION
 )
 
 from .plugins import init_plugins, find_plugin
@@ -1513,8 +1513,8 @@ class Modes(object):
         cursor = connection.cursor(db.dict_cursor)
         # Deliberately omit "drop" as it's a special case only supported in very limited circumstances and shouldn't
         # be thrown all over the UI
-        mode_query = 'SELECT `name` FROM `mode` WHERE `name` != %s'
-        cursor.execute(mode_query, MODE_DROP)
+        mode_query = 'SELECT `name` FROM `mode` WHERE `name` != "drop"'
+        cursor.execute(mode_query)
         payload = [r['name'] for r in cursor]
         cursor.close()
         connection.close()

--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -32,7 +32,7 @@ from iris_api.sender.quota import get_application_quotas_query
 
 
 from .constants import (
-    XFRAME, XCONTENTTYPEOPTIONS, XXSSPROTECTION
+    XFRAME, XCONTENTTYPEOPTIONS, XXSSPROTECTION, MODE_DROP
 )
 
 from .plugins import init_plugins, find_plugin
@@ -409,6 +409,13 @@ JOIN `mode`  on `mode`.`id` = `default_application_mode`.`mode_id`
 JOIN `priority` on `priority`.`id` = `default_application_mode`.`priority_id`
 JOIN `application` on `application`.`id` = `default_application_mode`.`application_id`
 WHERE `application`.`name` = %s'''
+
+get_supported_application_modes_query = '''
+SELECT `mode`.`name`
+FROM `mode`
+JOIN `application_mode` on `mode`.`id` = `application_mode`.`mode_id`
+WHERE `application_mode`.`application_id` = %s
+'''
 
 insert_user_modes_query = '''INSERT
 INTO `target_mode` (`priority_id`, `target_id`, `mode_id`)
@@ -1437,6 +1444,9 @@ class Application(object):
         cursor.execute(get_default_application_modes_query, app_name)
         app['default_modes'] = {row['priority']: row['mode'] for row in cursor}
 
+        cursor.execute(get_supported_application_modes_query, app['id'])
+        app['supported_modes'] = [row['name'] for row in cursor]
+
         cursor.close()
         connection.close()
 
@@ -1480,8 +1490,13 @@ class Applications(object):
                 app['variables'].append(row['name'])
                 if row['required']:
                     app['required_variables'].append(row['name'])
+
             cursor.execute(get_default_application_modes_query, app['name'])
             app['default_modes'] = {row['priority']: row['mode'] for row in cursor}
+
+            cursor.execute(get_supported_application_modes_query, app['id'])
+            app['supported_modes'] = [row['name'] for row in cursor]
+
             del app['id']
         payload = apps
         cursor.close()
@@ -1496,12 +1511,13 @@ class Modes(object):
     def on_get(self, req, resp):
         connection = db.engine.raw_connection()
         cursor = connection.cursor(db.dict_cursor)
-        mode_query = 'SELECT `id`,`name` FROM `mode`'''
-        cursor.execute(mode_query)
-        results = cursor.fetchall()
+        # Deliberately omit "drop" as it's a special case only supported in very limited circumstances and shouldn't
+        # be thrown all over the UI
+        mode_query = 'SELECT `name` FROM `mode` WHERE `name` != %s'
+        cursor.execute(mode_query, MODE_DROP)
+        payload = [r['name'] for r in cursor]
         cursor.close()
         connection.close()
-        payload = [r['name'] for r in results]
         resp.status = HTTP_200
         resp.body = ujson.dumps(payload)
 

--- a/src/iris_api/cache.py
+++ b/src/iris_api/cache.py
@@ -21,6 +21,11 @@ def cache_applications():
             'SELECT `name` FROM `template_variable` WHERE `application_id` = %s',
             app['id'])
         app['variables'] = [row['name'] for row in cursor]
+        cursor.execute('''SELECT `mode`.`name`
+                          FROM `mode`
+                          JOIN `application_mode` on `mode`.`id` = `application_mode`.`mode_id`
+                          WHERE `application_mode`.`application_id` = %s''', app['id'])
+        app['supported_modes'] = [row['name'] for row in cursor]
         applications[app['name']] = app
     connection.close()
     cursor.close()

--- a/src/iris_api/constants.py
+++ b/src/iris_api/constants.py
@@ -12,3 +12,6 @@ CALL_SUPPORT = 'call'
 EMAIL_SUPPORT = 'email'
 IM_SUPPORT = 'im'
 SLACK_SUPPORT = 'slack'
+
+# Avoid using magic strings for the special-case "drop" mode
+MODE_DROP = 'drop'

--- a/src/iris_api/constants.py
+++ b/src/iris_api/constants.py
@@ -12,6 +12,3 @@ CALL_SUPPORT = 'call'
 EMAIL_SUPPORT = 'email'
 IM_SUPPORT = 'im'
 SLACK_SUPPORT = 'slack'
-
-# Avoid using magic strings for the special-case "drop" mode
-MODE_DROP = 'drop'

--- a/src/iris_api/sender/quota.py
+++ b/src/iris_api/sender/quota.py
@@ -185,7 +185,7 @@ class ApplicationQuota(object):
             logger.warning('Application %s breached soft quota. Cannot notify owners as application is not set')
             return
 
-        if not all(target_name, target_role):
+        if not target_name or not target_role:
             logger.error('Application %s breached soft quota. Cannot notify owner as they aren\'t set (may have been deleted).')
             return
 

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1239,7 +1239,7 @@ def test_post_plan_noc(sample_user, sample_team, sample_application_name):
 
 
 def test_get_applications(sample_application_name):
-    app_keys = set(['variables', 'required_variables', 'name', 'context_template', 'summary_template', 'sample_context', 'default_modes'])
+    app_keys = set(['variables', 'required_variables', 'name', 'context_template', 'summary_template', 'sample_context', 'default_modes', 'supported_modes'])
     # TODO: insert application data before get
     re = requests.get(base_url + 'applications/' + sample_application_name)
     assert re.status_code == 200
@@ -1344,6 +1344,7 @@ def test_get_modes():
     assert 'email' in data
     assert 'call' in data
     assert 'im' in data
+    assert 'drop' not in data
 
 
 def test_get_priorities():

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -14,6 +14,7 @@ def test_configure(mocker):
     mocker.patch('iris_api.db.init')
     mocker.patch('iris_api.bin.sender.api_cache.cache_priorities')
     mocker.patch('iris_api.bin.sender.api_cache.cache_applications')
+    mocker.patch('iris_api.bin.sender.api_cache.cache_modes')
     init_sender({
         'db': {
             'conn': {


### PR DESCRIPTION
- Add application_mode table which specifies which modes are supported for each application
- Add "drop" mode type which sender understands to mean /dev/null
- change a few logger.error's to logger.exception's to make debugging easier
- when hard quota is exceeded, log message as type changed to "DROP"
- when hard quota is exceeded, properly update UI and message table to acknowledge that it was dropped
- fix foreign key constraint that breaks when a plan is deliberately
  disabled (UI doesn't support this) and is bound to a quota.