### PR TITLE
Add functionality to alter quotas with the concept of ownership

### DIFF
--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -605,6 +605,18 @@ CREATE TABLE `application_mode` (
   CONSTRAINT `application_mode_mode_id_ibfk` FOREIGN KEY (`mode_id`) REFERENCES `mode` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+--
+-- Table structure for table `application_owner`
+--
+
+DROP TABLE IF EXISTS `application_owner`;
+CREATE TABLE `application_owner` (
+  `application_id` int(11) NOT NULL,
+  `user_id` bigint(20) NOT NULL,
+  PRIMARY KEY (`application_id`, `user_id`),
+  CONSTRAINT `application_owner_application_id_ibfk` FOREIGN KEY (`application_id`) REFERENCES `application` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `application_owner_user_id_ibfk` FOREIGN KEY (`user_id`) REFERENCES `user` (`target_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -28,7 +28,8 @@ from . import db
 from . import utils
 from . import cache
 from iris_api.sender import auditlog
-from iris_api.sender.quota import get_application_quotas_query, insert_application_quota_query, required_quota_keys
+from iris_api.sender.quota import (get_application_quotas_query, insert_application_quota_query,
+                                   required_quota_keys, quota_int_keys)
 
 
 from .constants import (
@@ -1550,11 +1551,8 @@ class ApplicationQuota(object):
         if data.viewkeys() != required_quota_keys:
             raise HTTPBadRequest('Missing required keys in post body', '')
 
-        int_keys = set(['hard_quota_threshold', 'soft_quota_threshold',
-                        'hard_quota_duration', 'soft_quota_duration', 'wait_time'])
-
         try:
-            for key in int_keys:
+            for key in quota_int_keys:
                 if int(data[key]) < 1:
                     raise HTTPBadRequest('All int keys must be over 0', '')
         except ValueError:

--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -466,6 +466,27 @@ check_username_admin_query = '''SELECT `user`.`admin`
                                 JOIN `target_type` ON `target_type`.`id` = `target`.`type_id`
                                 WHERE `target`.`name` = %s
                                 AND `target_type`.`name` = "user"'''
+
+insert_application_quota_query = '''INSERT INTO `application_quota` (`application_id`, `hard_quota_threshold`,
+                                                                     `soft_quota_threshold`, `hard_quota_duration`,
+                                                                     `soft_quota_duration`, `plan_name`,
+                                                                     `target_id`, `wait_time`)
+                                    VALUES (:application_id, :hard_quota_threshold, :soft_quota_threshold,
+                                            :hard_quota_duration, :soft_quota_duration, :plan_name, :target_id, :wait_time)
+                                    ON DUPLICATE KEY UPDATE `hard_quota_threshold` = :hard_quota_threshold,
+                                                            `soft_quota_threshold` = :soft_quota_threshold,
+                                                            `hard_quota_duration` = :hard_quota_duration,
+                                                            `soft_quota_duration` = :soft_quota_duration,
+                                                            `plan_name` = :plan_name,
+                                                            `target_id` = :target_id,
+                                                            `wait_time` = :wait_time'''
+
+check_application_ownership_query = '''SELECT 1
+                                       FROM `application_owner`
+                                       JOIN `target` on `target`.`id` = `application_owner`.`user_id`
+                                       WHERE `target`.`name` = :username
+                                       AND `application_owner`.`application_id` = :application_id'''
+
 uuid4hex = re.compile('[0-9a-f]{32}\Z', re.I)
 
 
@@ -1517,7 +1538,6 @@ class Application(object):
         resp.body = ujson.dumps(payload)
 
 
-#  TODO: functionality to change quotas via API, which requires ACLs/etc
 class ApplicationQuota(object):
     allow_read_only = True
 
@@ -1533,6 +1553,66 @@ class ApplicationQuota(object):
             resp.body = '{}'
             raise HTTPNotFound()
         resp.body = ujson.dumps(quota)
+
+    def on_post(self, req, resp, app_name):
+
+        try:
+            data = ujson.loads(req.context['body'])
+        except ValueError:
+            raise HTTPBadRequest('Invalid json in post body', '')
+
+        required_keys = set(['hard_quota_threshold', 'soft_quota_threshold',
+                             'hard_quota_duration', 'soft_quota_duration',
+                             'plan_name', 'wait_time', 'target_name'])
+
+        int_keys = set(['hard_quota_threshold', 'soft_quota_threshold',
+                        'hard_quota_duration', 'soft_quota_duration', 'wait_time'])
+
+        if data.viewkeys() != required_keys:
+            raise HTTPBadRequest('Missing required keys in post body', '')
+
+        try:
+            for key in int_keys:
+                if int(data[key]) < 1:
+                    raise HTTPBadRequest('All int keys must be over 0', '')
+        except ValueError:
+            raise HTTPBadRequest('Some int keys are not integers', '')
+
+        if data['hard_quota_threshold'] <= data['soft_quota_threshold']:
+            raise HTTPBadRequest('Hard threshold must be bigger than soft threshold', '')
+
+        session = db.Session()
+
+        application_id = session.execute('SELECT `id` FROM `application` WHERE `name` = :app_name', {'app_name': app_name}).scalar()
+
+        if not application_id:
+            session.close()
+            raise HTTPBadRequest('No ID found for that application', '')
+
+        # Only admins and application owners can change quota settings
+        if not req.context['is_admin']:
+            if not session.execute(check_application_ownership_query, {'application_id': application_id, 'username': req.context['username']}).scalar():
+                session.close()
+                raise HTTPUnauthorized('You don\'t have permissions to update this app\'s quota.', '')
+
+        if not session.execute('SELECT 1 FROM `plan_active` WHERE `name` = :plan_name', data).scalar():
+            session.close()
+            raise HTTPBadRequest('No active ID found for that plan', '')
+
+        target_id = session.execute('SELECT `id` FROM `target` WHERE `name` = :target_name', data).scalar()
+
+        if not target_id:
+            session.close()
+            raise HTTPBadRequest('No ID found for that target', '')
+
+        data['application_id'] = application_id
+        data['target_id'] = target_id
+
+        session.execute(insert_application_quota_query, data)
+        session.commit()
+        session.close()
+
+        resp.status = HTTP_201
 
 
 class Applications(object):

--- a/src/iris_api/sender/quota.py
+++ b/src/iris_api/sender/quota.py
@@ -51,6 +51,8 @@ required_quota_keys = frozenset(['hard_quota_threshold', 'soft_quota_threshold',
                                  'hard_quota_duration', 'soft_quota_duration',
                                  'plan_name', 'wait_time', 'target_name'])
 
+quota_int_keys = ('hard_quota_threshold', 'soft_quota_threshold',
+                  'hard_quota_duration', 'soft_quota_duration', 'wait_time')
 
 
 class ApplicationQuota(object):

--- a/src/iris_api/sender/quota.py
+++ b/src/iris_api/sender/quota.py
@@ -27,11 +27,30 @@ get_application_quotas_query = '''SELECT `application`.`name` as application,
                                  LEFT JOIN `target` on `target`.`id` = `application_quota`.`target_id`
                                  LEFT JOIN `target_type` on `target_type`.`id` = `target`.`type_id` '''
 
+insert_application_quota_query = '''INSERT INTO `application_quota` (`application_id`, `hard_quota_threshold`,
+                                                                     `soft_quota_threshold`, `hard_quota_duration`,
+                                                                     `soft_quota_duration`, `plan_name`,
+                                                                     `target_id`, `wait_time`)
+                                    VALUES (:application_id, :hard_quota_threshold, :soft_quota_threshold,
+                                            :hard_quota_duration, :soft_quota_duration, :plan_name, :target_id, :wait_time)
+                                    ON DUPLICATE KEY UPDATE `hard_quota_threshold` = :hard_quota_threshold,
+                                                            `soft_quota_threshold` = :soft_quota_threshold,
+                                                            `hard_quota_duration` = :hard_quota_duration,
+                                                            `soft_quota_duration` = :soft_quota_duration,
+                                                            `plan_name` = :plan_name,
+                                                            `target_id` = :target_id,
+                                                            `wait_time` = :wait_time'''
+
 create_incident_query = '''INSERT INTO `incident` (`plan_id`, `created`, `context`, `current_step`, `active`, `application_id`)
                            VALUES ((SELECT `plan_id` FROM `plan_active` WHERE `name` = :plan_name),
                                    :created, :context, 0, TRUE, :sender_app_id)'''
 
 check_incident_claimed_query = '''SELECT `active` FROM `incident` WHERE `id` = :id'''
+
+required_quota_keys = frozenset(['hard_quota_threshold', 'soft_quota_threshold',
+                                 'hard_quota_duration', 'soft_quota_duration',
+                                 'plan_name', 'wait_time', 'target_name'])
+
 
 
 class ApplicationQuota(object):


### PR DESCRIPTION
- Add idempotent endpoint for setting quotas for an application

- Add application_owner table which binds people to being owners of an app,
  and these owners are allowed to set quotas. (In future PRs, reset API keys
  and context variables/etc)