### PR TITLE
Add email/sms claim all support

### DIFF
--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -90,7 +90,9 @@ INSERT INTO `target_application_mode` VALUES (1,8,26,26);
 UNLOCK TABLES;
 
 LOCK TABLES `target_contact` WRITE;
-INSERT INTO `target_contact` VALUES (1,8,'+1 123-456-7890'),(1,17,'demo'),(1,26,'+1 123-456-7890'),(1,35,'demo@foo.bar');
+INSERT INTO `target_contact` VALUES (1,8,'+1 123-456-7891'),(1,17,'demo1'),(1,26,'+1 123-456-7891'),(1,35,'demo1@foo.bar'),
+                                    (2,8,'+1 123-456-7892'),(2,17,'demo2'),(2,26,'+1 123-456-7892'),(2,35,'demo2@foo.bar'),
+                                    (3,8,'+1 123-456-7893'),(3,17,'demo3'),(3,26,'+1 123-456-7893'),(3,35,'demo3@foo.bar');
 UNLOCK TABLES;
 
 LOCK TABLES `target_mode` WRITE;

--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -90,9 +90,9 @@ INSERT INTO `target_application_mode` VALUES (1,8,26,26);
 UNLOCK TABLES;
 
 LOCK TABLES `target_contact` WRITE;
-INSERT INTO `target_contact` VALUES (1,8,'+1 123-456-7891'),(1,17,'demo1'),(1,26,'+1 123-456-7891'),(1,35,'demo1@foo.bar'),
-                                    (2,8,'+1 123-456-7892'),(2,17,'demo2'),(2,26,'+1 123-456-7892'),(2,35,'demo2@foo.bar'),
-                                    (3,8,'+1 123-456-7893'),(3,17,'demo3'),(3,26,'+1 123-456-7893'),(3,35,'demo3@foo.bar');
+INSERT INTO `target_contact` VALUES (1,8,'+1 407-456-7891'),(1,17,'demo1'),(1,26,'+1 407-456-7891'),(1,35,'demo1@foo.bar'),
+                                    (2,8,'+1 407-456-7892'),(2,17,'demo2'),(2,26,'+1 407-456-7892'),(2,35,'demo2@foo.bar'),
+                                    (3,8,'+1 407-456-7893'),(3,17,'demo3'),(3,26,'+1 407-456-7893'),(3,35,'demo3@foo.bar');
 UNLOCK TABLES;
 
 LOCK TABLES `target_mode` WRITE;

--- a/src/iris_api/plugins/core.py
+++ b/src/iris_api/plugins/core.py
@@ -85,24 +85,22 @@ class IrisPlugin(object):
             return 'Failed to identify owner for these incidents.'
         if not msg_ids:
             return 'No messages to claim.'
-        claimed = set()
-        failed_to_claim = set()
-        for msg_id in msg_ids:
-            iid = utils.get_incident_id_from_message_id(msg_id)
-            if not iid:
-                logger.error('Couldn\'t get incident ID from message id %s', msg_id)
-                continue
-            is_active = utils.claim_incident(iid, owner)
-            if is_active:
-                failed_to_claim.add(str(iid))
-            else:
-                claimed.add(str(iid))
+        incident_ids = utils.get_incident_ids_from_message_ids(msg_ids)
+        if not incident_ids:
+            return 'No messages to claim.'
+
+        claimed, not_claimed = utils.claim_bulk_incidents(incident_ids, owner)
+
         msg = []
         if claimed:
-            msg.append('Iris Incidents claimed: %s' % ', '.join(claimed))
-        if failed_to_claim:
-            msg.append('Iris Incidents failed to claim: %s' % ', '.join(failed_to_claim))
-        return '\n'.join(msg)
+            msg.append('Iris Incidents claimed: %s' % ', '.join(map(str, claimed)))
+        if not_claimed:
+            msg.append('Iris Incidents failed to claim: %s' % ', '.join(map(str, not_claimed)))
+
+        if msg:
+            return '\n'.join(msg)
+        else:
+            return 'Unknown claim all result'
 
     def process_command(self, msg_id, source, mode, cmd, args=None):
         if cmd == 'claim':

--- a/src/iris_api/utils.py
+++ b/src/iris_api/utils.py
@@ -55,6 +55,16 @@ def parse_response(response, mode, source):
                                     LIMIT 1''', {'target_name': target_name}).scalar()
         session.close()
         return msg_id, 'claim'
+    elif re.match('[cC]laim\s+all', response):
+        session = db.Session()
+        target_name = lookup_username_from_contact(mode, source, session=session)
+        msg_ids = [row[0] for row in session.execute('''SELECT `message`.`id` from `message`
+                                                        JOIN `target` on `target`.`id` = `message`.`target_id`
+                                                        JOIN `incident` on `incident`.`id` = `message`.`incident_id`
+                                                        WHERE `target`.`name` = :target_name
+                                                        AND `incident`.`active` = TRUE''', {'target_name': target_name})]
+        session.close()
+        return msg_ids, 'claim_all'
 
     return halves
 

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -234,6 +234,7 @@ def create_incident_with_message(application, plan, target, mode):
                                   TRUE,
                                   %(incident_id)s
                           )''', {'application': application, 'target': target, 'mode': mode, 'incident_id': incident_id})
+        assert cursor.lastrowid
         conn.commit()
         return incident_id
 


### PR DESCRIPTION
- When 'claim all' submitted through sms or email, claim all incidents currently being sent to that user
- Reply to user with a list of incident IDs that were claimed as a result