### PR TITLE
Avoid SMS messages appearing with leading dot

### DIFF
--- a/src/iris_api/vendors/iris_twilio.py
+++ b/src/iris_api/vendors/iris_twilio.py
@@ -27,15 +27,26 @@ class iris_twilio(object):
         return TwilioRestClient(self.config['account_sid'],
                                 self.config['auth_token'])
 
+    def generate_message_text(self, message):
+        content = []
+
+        for key in ('subject', 'body'):
+            value = message.get(key)
+            if not isinstance(value, basestring):
+                continue
+            value = value.strip()
+            if value:
+                content.append(value)
+
+        return '. '.join(content)
+
     def send_sms(self, message):
         client = self.get_twilio_client()
 
         sender = client.messages.create
         from_ = self.config['twilio_number']
         start = time.time()
-        content = message['subject']
-        if 'body' in message:
-            content += '. %s' % message['body']
+        content = self.generate_message_text(message)
         sender(to=message['destination'],
                from_=from_,
                body=content[:480])
@@ -51,9 +62,7 @@ class iris_twilio(object):
         sender = client.calls.create
         from_ = self.config['twilio_number']
         url = self.config['relay_base_url'] + '/api/v0/twilio/calls/gather?'
-        content = message['subject']
-        if 'body' in message:
-            content += '. %s' % message['body']
+        content = self.generate_message_text(message)
 
         start = time.time()
         qs = urllib.urlencode({

--- a/test/test_iris_vendor_twilio.py
+++ b/test/test_iris_vendor_twilio.py
@@ -1,0 +1,13 @@
+# Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+# See LICENSE in the project root for license information.
+
+
+def test_twilio_message_generate(mocker):
+    mocker.patch('twilio.rest.resources.Connection')
+    from iris_api.vendors.iris_twilio import iris_twilio
+    twilio = iris_twilio({})
+    assert twilio.generate_message_text({}) == ''
+    assert twilio.generate_message_text({'subject': '', 'body': ''}) == ''
+    assert twilio.generate_message_text({'subject': 'Foo', 'body': 'Bar'}) == 'Foo. Bar'
+    assert twilio.generate_message_text({'body': 'FooBar'}) == 'FooBar'
+    assert twilio.generate_message_text({'subject': 'FooBar'}) == 'FooBar'


### PR DESCRIPTION
- When a SMS just has a body and no subject, it will appear with a leading dot
- Improve logic to avoid this for calls and SMS