### PR TITLE
Add whether or not user is admin to the user info endpoint

### DIFF
--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -1791,15 +1791,18 @@ class User(object):
         connection = db.engine.raw_connection()
         cursor = connection.cursor(db.dict_cursor)
         # Get user id/name
-        user_query = ''' SELECT `id`, `name` FROM `target`'''
+        user_query = '''SELECT `target`.`id`, `target`.`name`, `user`.`admin`
+                        FROM `target`
+                        JOIN `user` on `user`.`target_id` = `target`.`id`'''
         if username.isdigit():
-            user_query += ' WHERE `id` = %s'
+            user_query += ' WHERE `target`.`id` = %s'
         else:
-            user_query += ' WHERE `name` = %s'
+            user_query += ' WHERE `target`.`name` = %s'
         cursor.execute(user_query, username)
         if cursor.rowcount != 1:
             raise HTTPNotFound()
         user_data = cursor.fetchone()
+        user_data['admin'] = bool(user_data['admin'])
         user_id = user_data.pop('id')
 
         # Get user contact modes

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1623,15 +1623,17 @@ def test_get_priorities():
     assert 'urgent' in data
 
 
-def test_get_user(sample_user, sample_email):
+def test_get_user(sample_user, sample_email, sample_admin_user):
     re = requests.get(base_url + 'users/' + sample_user, headers=username_header(sample_user))
     assert re.status_code == 200
     data = re.json()
+    assert data.viewkeys() == {'teams', 'modes', 'per_app_modes', 'admin', 'contacts', 'name'}
     assert data['contacts']['email'] == sample_email
     assert data['name'] == sample_user
-    assert 'teams' in data
-    assert 'modes' in data
-    assert 'per_app_modes' in data
+
+    re = requests.get(base_url + 'users/' + sample_admin_user, headers=username_header(sample_admin_user))
+    assert re.status_code == 200
+    assert re.json()['admin'] is True
 
 
 def test_healthcheck():


### PR DESCRIPTION
This way iris-frontend can decide what fields/etc to show to the user, primarily
being the ability to edit application owners and quotas.