### PR TITLE
Make deleting quota return valid json

### DIFF
--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -1712,6 +1712,7 @@ class ApplicationQuota(object):
         session.close()
 
         resp.status = HTTP_204
+        resp.body = '{}'
 
 
 class Applications(object):


### PR DESCRIPTION
Avoid jquery/ajax getting confused when the response isn't valid json