### PR TITLE
Tweaks for slack support

### DIFF
--- a/src/iris_api/bin/sender.py
+++ b/src/iris_api/bin/sender.py
@@ -207,7 +207,8 @@ quota = None
 default_sender_metrics = {
     'email_cnt': 0, 'email_total': 0, 'email_fail': 0, 'email_sent': 0, 'email_max': 0,
     'email_min': 0, 'email_avg': 0, 'im_cnt': 0, 'im_total': 0, 'im_fail': 0, 'im_sent': 0,
-    'im_max': 0, 'im_min': 0, 'im_avg': 0, 'sms_cnt': 0, 'sms_total': 0, 'sms_fail': 0,
+    'im_max': 0, 'im_min': 0, 'im_avg': 0, 'slack_cnt': 0, 'slack_total': 0, 'slack_fail': 0,
+    'slack_sent': 0, 'slack_max': 0, 'slack_min': 0, 'slack_avg': 0, 'sms_cnt': 0, 'sms_total': 0, 'sms_fail': 0,
     'sms_sent': 0, 'sms_max': 0, 'sms_min': 0, 'sms_avg': 0, 'call_cnt': 0, 'call_total': 0,
     'call_fail': 0, 'call_sent': 0, 'call_max': 0, 'call_min': 0, 'call_avg': 0, 'task_failure': 0,
     'oncall_error': 0, 'role_target_lookup_error': 0, 'target_not_found': 0, 'message_send_cnt': 0,

--- a/src/iris_api/vendors/iris_dummy.py
+++ b/src/iris_api/vendors/iris_dummy.py
@@ -2,13 +2,13 @@
 # See LICENSE in the project root for license information.
 
 import logging
-from iris_api.constants import EMAIL_SUPPORT, IM_SUPPORT, CALL_SUPPORT, SMS_SUPPORT
+from iris_api.constants import EMAIL_SUPPORT, IM_SUPPORT, CALL_SUPPORT, SMS_SUPPORT, SLACK_SUPPORT
 
 logger = logging.getLogger(__name__)
 
 
 class iris_dummy(object):
-    supports = frozenset([EMAIL_SUPPORT, IM_SUPPORT, CALL_SUPPORT, SMS_SUPPORT])
+    supports = frozenset([EMAIL_SUPPORT, IM_SUPPORT, CALL_SUPPORT, SMS_SUPPORT, SLACK_SUPPORT])
 
     def __init__(self, config):
         self.time_taken = 1


### PR DESCRIPTION
- Updated sync_script to populate slack instead of IM
- Updated sync_script to hit the new oncall endpoint to get the list of teams
- Update sender to emit metrics for slack. Imho that should really be a defaultdict
  but there may be implications for changing it
- Make the locally testing iris_dummy vendor support slack
- Tested that slack messages get created and "sent" properly through dummy