### PR TITLE
Add median seconds to claim and percent incidents claimed stats

### DIFF
--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1655,9 +1655,10 @@ def test_stats():
     re = requests.get(base_url + 'stats')
     assert re.status_code == 200
     data = re.json()
-    for key in ['total_active_users', 'total_messages_sent_today', 'total_incidents_today', 'total_messages_sent', 'total_incidents', 'total_plans']:
+    for key in ('total_active_users', 'total_messages_sent_today', 'total_incidents_today', 'total_messages_sent',
+                'total_incidents', 'total_plans', 'pct_incidents_claimed_last_month', 'median_seconds_to_claim_last_month'):
         assert key in data
-        assert isinstance(data[key], int)
+        assert isinstance(data[key], int) or isinstance(data[key], float)
 
 
 def test_post_notification(sample_user, sample_application_name):


### PR DESCRIPTION
- Add these two queries to stats endpoint

- Algorithm for median in MySQL is from https://www.periscopedata.com/blog/medians-in-sql.html

- Using a SELECT instead of SET for the temp variables that query needs because apparently
  python mysql does not like SET statements in the same query call, which creates the need for
  accessing the result index by -1 to grab the last element returned. Converting from sqlalchemy
  session to raw cursor as I can't index fields by -1 in session but it works in cursor.