### PR TITLE
Initial support for twilio delivery status tracking for SMS/CALLS

### DIFF
--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -617,6 +617,20 @@ CREATE TABLE `application_owner` (
   CONSTRAINT `application_owner_user_id_ibfk` FOREIGN KEY (`user_id`) REFERENCES `user` (`target_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+--
+-- Table structure for table `twilio_delivery_status`
+--
+
+DROP TABLE IF EXISTS `twilio_delivery_status`;
+CREATE TABLE `twilio_delivery_status` (
+  `twilio_sid` varchar(34) NOT NULL,
+  `message_id` bigint(20) DEFAULT NULL,
+  `status` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`twilio_sid`),
+  KEY `twilio_delivery_status_message_id_fk_idx` (`message_id`),
+  CONSTRAINT `twilio_delivery_status_message_id_ibfk` FOREIGN KEY (`message_id`) REFERENCES `message` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -115,12 +115,14 @@ single_message_query = '''SELECT `message`.`id` as `id`,
     `mode`.`name` as `mode`,
     `application`.`name` as `application`,
     `priority`.`name` as `priority`,
-    `target`.`name` as `target`
+    `target`.`name` as `target`,
+    `twilio_delivery_status`.`status` as `twilio_delivery_status`
 FROM `message`
 JOIN `priority` ON `message`.`priority_id` = `priority`.`id`
 JOIN `application` ON `message`.`application_id` = `application`.`id`
 JOIN `mode` ON `message`.`mode_id` = `mode`.`id`
 JOIN `target` ON `message`.`target_id`=`target`.`id`
+LEFT JOIN `twilio_delivery_status` ON `twilio_delivery_status`.`message_id` = `message`.`id`
 WHERE `message`.`id` = %s'''
 
 message_audit_log_query = '''SELECT `id`, `date`, `old`, `new`, `change_type`, `description`
@@ -2222,6 +2224,32 @@ class ResponseSlack(ResponseMixin):
             resp.body = ujson.dumps({'app_response': response})
 
 
+class TwilioDeliveryUpdate(object):
+    allow_read_only = False
+
+    def on_post(self, req, resp):
+        try:
+            info = ujson.loads(req.context['body'])
+        except ValueError:
+            raise HTTPBadRequest('Invalid json in post body', '')
+
+        for required_param in ('status', 'sid'):
+            if required_param not in info:
+                raise HTTPBadRequest('Missing %s from post body' % required_param, '')
+
+        session = db.Session()
+        affected = session.execute('''UPDATE `twilio_delivery_status`
+                                      SET `status` = :status
+                                      WHERE `twilio_sid` = :sid''', info).rowcount
+        session.commit()
+        session.close()
+
+        if not affected:
+            raise HTTPBadRequest('Invalid twilio sid')
+
+        resp.status = HTTP_204
+
+
 class Reprioritization(object):
     allow_read_only = False
     enforce_user = True
@@ -2437,7 +2465,39 @@ class ApplicationStats(object):
                                                                   AND `application_id` = %(application_id)s
                                                                   ORDER BY time_to_claim) as time_to_claim
                                                             WHERE (SELECT @row_id := @row_id + 1)
-                                                            BETWEEN @incident_count/2.0 AND @incident_count/2.0 + 1)'''
+                                                            BETWEEN @incident_count/2.0 AND @incident_count/2.0 + 1)''',
+            'pct_successful_sms_last_month': '''SELECT ROUND((SELECT count(*) FROM `message`
+                                                              JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
+                                                              JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                                                              WHERE `twilio_delivery_status`.`status` = 'delivered'
+                                                                    AND `mode`.`name` = 'sms'
+                                                                    AND `message`.`application_id` = %(application_id)s
+                                                                    AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                    AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)) /
+                                                             (SELECT count(*) FROM `message`
+                                                              JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
+                                                              JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                                                              WHERE NOT ISNULL(`twilio_delivery_status`.`status`)
+                                                                    AND `mode`.`name` = 'sms'
+                                                                    AND `message`.`application_id` = %(application_id)s
+                                                                    AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                    AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)), 2) * 100''',
+            'pct_successful_call_last_month': '''SELECT ROUND((SELECT count(*) FROM `message`
+                                                               JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
+                                                               JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                                                               WHERE `twilio_delivery_status`.`status` = 'completed'
+                                                                     AND `mode`.`name` = 'call'
+                                                                     AND `message`.`application_id` = %(application_id)s
+                                                                     AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                     AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)) /
+                                                              (SELECT count(*) FROM `message`
+                                                               JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
+                                                               JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                                                               WHERE NOT ISNULL(`twilio_delivery_status`.`status`)
+                                                                     AND `mode`.`name` = 'call'
+                                                                     AND `message`.`application_id` = %(application_id)s
+                                                                     AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                     AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)), 2) * 100''',
         }
 
         query_data = {'application_id': app['id']}
@@ -2538,6 +2598,7 @@ def get_api(config):
     app.add_route('/v0/response/twilio/calls', ResponseTwilioCalls(iris_sender_app))
     app.add_route('/v0/response/twilio/messages', ResponseTwilioMessages(iris_sender_app))
     app.add_route('/v0/response/slack', ResponseSlack(iris_sender_app))
+    app.add_route('/v0/twilio/deliveryupdate', TwilioDeliveryUpdate())
 
     app.add_route('/v0/stats', Stats())
 

--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -2466,38 +2466,38 @@ class ApplicationStats(object):
                                                                   ORDER BY time_to_claim) as time_to_claim
                                                             WHERE (SELECT @row_id := @row_id + 1)
                                                             BETWEEN @incident_count/2.0 AND @incident_count/2.0 + 1)''',
-            'pct_successful_sms_last_month': '''SELECT ROUND((SELECT count(*) FROM `message`
-                                                              JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
-                                                              JOIN `mode` on `mode`.`id` = `message`.`mode_id`
-                                                              WHERE `twilio_delivery_status`.`status` = 'delivered'
-                                                                    AND `mode`.`name` = 'sms'
-                                                                    AND `message`.`application_id` = %(application_id)s
-                                                                    AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
-                                                                    AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)) /
-                                                             (SELECT count(*) FROM `message`
-                                                              JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
-                                                              JOIN `mode` on `mode`.`id` = `message`.`mode_id`
-                                                              WHERE NOT ISNULL(`twilio_delivery_status`.`status`)
-                                                                    AND `mode`.`name` = 'sms'
-                                                                    AND `message`.`application_id` = %(application_id)s
-                                                                    AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
-                                                                    AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)), 2) * 100''',
-            'pct_successful_call_last_month': '''SELECT ROUND((SELECT count(*) FROM `message`
-                                                               JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
-                                                               JOIN `mode` on `mode`.`id` = `message`.`mode_id`
-                                                               WHERE `twilio_delivery_status`.`status` = 'completed'
-                                                                     AND `mode`.`name` = 'call'
-                                                                     AND `message`.`application_id` = %(application_id)s
-                                                                     AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
-                                                                     AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)) /
-                                                              (SELECT count(*) FROM `message`
-                                                               JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
-                                                               JOIN `mode` on `mode`.`id` = `message`.`mode_id`
-                                                               WHERE NOT ISNULL(`twilio_delivery_status`.`status`)
-                                                                     AND `mode`.`name` = 'call'
-                                                                     AND `message`.`application_id` = %(application_id)s
-                                                                     AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
-                                                                     AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)), 2) * 100''',
+            'pct_successful_twilio_sms_last_month': '''SELECT ROUND((SELECT count(*) FROM `message`
+                                                                     JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
+                                                                     JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                                                                     WHERE `twilio_delivery_status`.`status` = 'delivered'
+                                                                           AND `mode`.`name` = 'sms'
+                                                                           AND `message`.`application_id` = %(application_id)s
+                                                                           AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                           AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)) /
+                                                                    (SELECT count(*) FROM `message`
+                                                                     JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
+                                                                     JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                                                                     WHERE NOT ISNULL(`twilio_delivery_status`.`status`)
+                                                                           AND `mode`.`name` = 'sms'
+                                                                           AND `message`.`application_id` = %(application_id)s
+                                                                           AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                           AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)), 2) * 100''',
+            'pct_successful_twilio_call_last_month': '''SELECT ROUND((SELECT count(*) FROM `message`
+                                                                      JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
+                                                                      JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                                                                      WHERE `twilio_delivery_status`.`status` = 'completed'
+                                                                            AND `mode`.`name` = 'call'
+                                                                            AND `message`.`application_id` = %(application_id)s
+                                                                            AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                            AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)) /
+                                                                     (SELECT count(*) FROM `message`
+                                                                      JOIN `twilio_delivery_status` on `twilio_delivery_status`.`message_id` = `message`.`id`
+                                                                      JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                                                                      WHERE NOT ISNULL(`twilio_delivery_status`.`status`)
+                                                                            AND `mode`.`name` = 'call'
+                                                                            AND `message`.`application_id` = %(application_id)s
+                                                                            AND `message`.`created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                            AND `message`.`created` < (CURRENT_DATE - INTERVAL 1 DAY)), 2) * 100''',
         }
 
         query_data = {'application_id': app['id']}

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1676,7 +1676,7 @@ def test_app_stats(sample_application_name):
     data = re.json()
     for key in ('total_incidents_today', 'total_messages_sent_today',
                 'pct_incidents_claimed_last_month', 'median_seconds_to_claim_last_month',
-                'pct_successful_sms_last_month'):
+                'pct_successful_twilio_sms_last_month', 'pct_successful_twilio_call_last_month'):
         assert key in data
         assert isinstance(data[key], int) or isinstance(data[key], float)
 

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -11,6 +11,7 @@ import requests
 import copy
 import iris_api.bin.iris_ctl as iris_ctl
 from click.testing import CliRunner
+import uuid
 
 
 server = 'http://localhost:16649/'
@@ -44,7 +45,7 @@ def username_header(username):
 def iris_messages():
     '''List of iris messages'''
     with iris_ctl.db_from_config(sample_db_config) as (conn, cursor):
-        cursor.execute('SELECT `id`, `incident_id` FROM `message` WHERE NOT ISNULL(`incident_id`) LIMIT 3')
+        cursor.execute('SELECT `id`, `incident_id` FROM `message` WHERE NOT ISNULL(`incident_id`) ORDER BY `id` DESC LIMIT 3')
         return [dict(id=id, incident_id=incident_id) for (id, incident_id) in cursor]
 
 
@@ -1674,7 +1675,8 @@ def test_app_stats(sample_application_name):
     assert re.status_code == 200
     data = re.json()
     for key in ('total_incidents_today', 'total_messages_sent_today',
-                'pct_incidents_claimed_last_month', 'median_seconds_to_claim_last_month'):
+                'pct_incidents_claimed_last_month', 'median_seconds_to_claim_last_month',
+                'pct_successful_sms_last_month'):
         assert key in data
         assert isinstance(data[key], int) or isinstance(data[key], float)
 
@@ -1845,6 +1847,30 @@ def test_modify_application(sample_application_name, sample_admin_user, sample_u
     # Verify that mode is there
     re = requests.get(base_url + 'applications/%s' % sample_application_name)
     assert sample_mode in re.json()['supported_modes']
+
+
+def test_twilio_delivery_update(fake_message_id):
+    if not fake_message_id:
+        pytest.skip('We do not have enough data in DB to do this test')
+
+    re = requests.post(base_url + 'twilio/deliveryupdate', json={'sid': 'dsfds23442fakesid', 'status': 'delivered'})
+    assert re.status_code == 400
+    assert re.json()['title'] == 'Invalid twilio sid'
+
+    # Wouldn't surprise me if this is how twilio actually generates the SID on their end
+    message_sid = uuid.uuid4().hex
+
+    with iris_ctl.db_from_config(sample_db_config) as (conn, cursor):
+        cursor.execute('''INSERT INTO `twilio_delivery_status` (`twilio_sid`, `message_id`)
+                          VALUES (%s, %s)''', (message_sid, fake_message_id))
+        conn.commit()
+
+    re = requests.post(base_url + 'twilio/deliveryupdate', json={'sid': message_sid, 'status': 'delivered'})
+    assert re.status_code == 204
+
+    re = requests.get(base_url + 'messages/%s' % fake_message_id)
+    assert re.status_code == 200
+    assert re.json()['twilio_delivery_status'] == 'delivered'
 
 
 @pytest.mark.skip(reason="Re-enable this when we don't hard-code primary keys")


### PR DESCRIPTION
- Add endpoint for iris-relay to relay delivery updates from twilio

- Create table, with 1:1 mapping to messages, for storing the latest
  delivery update per message

- Add delivery status field to message endpoint. May or may not be null
  depending on whether we've received an update yet

- Pass iris-relay URL to the twilio message create methods