### PR TITLE
Support twilio status updates for calls as well as SMS

### DIFF
--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -2236,9 +2236,15 @@ class TwilioDeliveryUpdate(object):
                 'status': post_dict['MessageStatus'],
                 'sid': post_dict['MessageSid']
             }
-        except KeyError as e:
-            logger.exception('Invalid twilio delivery update request. Payload: %s', post_dict)
-            raise HTTPBadRequest('Missing %s from post body' % e, '')
+        except KeyError:
+            try:
+                info = {
+                    'status': post_dict['CallStatus'],
+                    'sid': post_dict['CallSid']
+                }
+            except KeyError:
+                logger.exception('Invalid twilio delivery update request. Payload: %s', post_dict)
+                raise HTTPBadRequest('Invalid keys in payload', '')
 
         session = db.Session()
         affected = session.execute('''UPDATE `twilio_delivery_status`

--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -2231,30 +2231,22 @@ class TwilioDeliveryUpdate(object):
     def on_post(self, req, resp):
         post_dict = falcon.uri.parse_query_string(req.context['body'])
 
-        try:
-            info = {
-                'status': post_dict['MessageStatus'],
-                'sid': post_dict['MessageSid']
-            }
-        except KeyError:
-            try:
-                info = {
-                    'status': post_dict['CallStatus'],
-                    'sid': post_dict['CallSid']
-                }
-            except KeyError:
-                logger.exception('Invalid twilio delivery update request. Payload: %s', post_dict)
-                raise HTTPBadRequest('Invalid keys in payload', '')
+        sid = post_dict.get('MessageSid', post_dict.get('CallSid'))
+        status = post_dict.get('MessageStatus', post_dict.get('CallStatus'))
+
+        if not sid or not status:
+            logger.exception('Invalid twilio delivery update request. Payload: %s', post_dict)
+            raise HTTPBadRequest('Invalid keys in payload', '')
 
         session = db.Session()
         affected = session.execute('''UPDATE `twilio_delivery_status`
                                       SET `status` = :status
-                                      WHERE `twilio_sid` = :sid''', info).rowcount
+                                      WHERE `twilio_sid` = :sid''', {'sid': sid, 'status': status}).rowcount
         session.commit()
         session.close()
 
         if not affected:
-            logger.warn('No rows changed when updating delivery status for twilio sid: %s', info['sid'])
+            logger.warn('No rows changed when updating delivery status for twilio sid: %s', sid)
 
         resp.status = HTTP_204
 

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1853,10 +1853,6 @@ def test_twilio_delivery_update(fake_message_id):
     if not fake_message_id:
         pytest.skip('We do not have enough data in DB to do this test')
 
-    re = requests.post(base_url + 'twilio/deliveryupdate', data={'MessageSid': 'dsfds23442fakesid', 'MessageStatus': 'delivered'})
-    assert re.status_code == 400
-    assert re.json()['title'] == 'Invalid twilio sid'
-
     # Wouldn't surprise me if this is how twilio actually generates the SID on their end
     message_sid = uuid.uuid4().hex
 


### PR DESCRIPTION
The keys are named differently for calls.

Also remove test against 400 as occasionally duplicate sid's are passed which is legal.