### PR TITLE
Actually fix issue with different applications mixing email addresses

### DIFF
--- a/src/iris_api/vendors/__init__.py
+++ b/src/iris_api/vendors/__init__.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 import logging
 import itertools
 import random
+import copy
 logger = logging.getLogger(__name__)
 
 _max_tries_per_message = 5
@@ -22,12 +23,12 @@ def init_vendors(vendors, application_vendors):
 
     vendor_instances = defaultdict(list)
     app_vendor_instances = defaultdict(lambda: defaultdict(list))
-    for vendor in vendors:
-        vendor_cls = import_custom_module('iris_api.vendors', vendor['type'])
+    for vendor_config in vendors:
+        vendor_cls = import_custom_module('iris_api.vendors', vendor_config['type'])
         for mode in vendor_cls.supports:
-            vendor_instances[mode].append(vendor_cls(vendor))
+            vendor_instances[mode].append(vendor_cls(copy.deepcopy(vendor_config)))
             for application_name, application_cls in applications.iteritems():
-                app_vendor_instances[application_name][mode].append(application_cls(vendor_cls(vendor)))
+                app_vendor_instances[application_name][mode].append(application_cls(vendor_cls(copy.deepcopy(vendor_config))))
 
     for mode, instances in vendor_instances.iteritems():
         random.shuffle(instances)


### PR DESCRIPTION
- Problem is we were passing the same reference to the same config dict
  to each app and to each vendor, so when one of them change it all of them
  are affected. Fix that here by deepcopy'ing it.

- Verified before/after with `id`

- Also rename `vendor` to `vendor_config` for clarity reasons.