### PR TITLE
Refactor metrics

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -3,7 +3,7 @@ server:
   port: 16649
   disable_auth: True
 role_lookup: dummy
-metrics: influx
+metrics: dummy
 
 # use this for LDAP settings for sync script lookup
 # init_config_hook: iris_internal.api.init_config

--- a/src/iris_api/metrics/__init__.py
+++ b/src/iris_api/metrics/__init__.py
@@ -2,6 +2,7 @@
 # See LICENSE in the project root for license information.
 
 from iris_api.custom_import import import_custom_module
+from gevent import sleep
 import logging
 logger = logging.getLogger(__name__)
 
@@ -15,10 +16,17 @@ def get_metrics_provider(config, app_name):
     return import_custom_module('iris_api.metrics', config['metrics'])(config, app_name)
 
 
-def emit_metrics():
+def emit():
     if metrics_provider:
         metrics_provider.send_metrics(stats)
     stats.update(stats_reset)
+
+
+# It's expected that you gevent.spawn this after you monkeypatch everything
+def emit_forever():
+    while True:
+        emit()
+        sleep(60)
 
 
 def init(config, app_name, default_stats):
@@ -26,3 +34,22 @@ def init(config, app_name, default_stats):
     metrics_provider = get_metrics_provider(config, app_name)
     stats_reset.update(default_stats)
     stats.update(stats_reset)
+
+
+def add_new_metrics(default_stats):
+    stats_reset.update(default_stats)
+
+    # avoid clobbering existing metrics if they are already present
+    for key, default_value in default_stats.iteritems():
+        stats.setdefault(key, default_value)
+
+
+def incr(key, inc=1):
+    try:
+        stats[key] += inc
+    except KeyError as e:
+        logger.exception('failed incrementing nonexistent metric: %s', e)
+
+
+def set(key, value):
+    stats[key] = value

--- a/src/iris_api/metrics/dummy.py
+++ b/src/iris_api/metrics/dummy.py
@@ -10,4 +10,4 @@ class dummy(object):
         self.appname = appname
 
     def send_metrics(self, metrics):
-        logger.debug('sending metrics: %s', metrics)
+        logging.info('Sending metrics: %s', ', '.join('%s: %s' % (key, metrics[key]) for key in sorted(metrics)))

--- a/src/iris_api/sender/shared.py
+++ b/src/iris_api/sender/shared.py
@@ -2,6 +2,30 @@
 # See LICENSE in the project root for license information.
 
 from gevent import queue
+from iris_api.metrics import stats
+import logging
+
+logger = logging.getLogger(__name__)
 
 # queue for sending messages
 send_queue = queue.Queue()
+
+
+def add_mode_stat(mode, runtime):
+    try:
+        stats[mode + '_cnt'] += 1
+        if runtime is None:
+            stats[mode + '_fail'] += 1
+        else:
+            stats[mode + '_total'] += runtime
+            stats[mode + '_sent'] += 1
+            if runtime > stats[mode + '_max']:
+                stats[mode + '_max'] = runtime
+            elif runtime < stats[mode + '_min']:
+                stats[mode + '_min'] = runtime
+            if runtime < stats[mode + '_min']:
+                stats[mode + '_min'] = runtime
+            elif runtime > stats[mode + '_max']:
+                stats[mode + '_max'] = runtime
+    except KeyError as e:
+        logger.exception('failed modifying nonexistent metric: %s', e)

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -253,14 +253,12 @@ def test_generate_slave_message_payload():
 
 def test_quotas(mocker):
     from iris_api.sender.quota import ApplicationQuota
-    from iris_api.bin.sender import add_application_stat
     from iris_api.metrics import stats
     from gevent import sleep
     mocker.patch('iris_api.sender.quota.ApplicationQuota.get_new_rules', return_value=[(u'testapp', 5, 2, 120, 120, u'testuser', u'user', u'iris-plan', 10)])
     mocker.patch('iris_api.sender.quota.ApplicationQuota.notify_incident')
     mocker.patch('iris_api.sender.quota.ApplicationQuota.notify_target')
-    stats['quota_hard_exceed_cnt'] = stats['quota_soft_exceed_cnt'] = 0
-    quotas = ApplicationQuota(None, None, None, add_application_stat)
+    quotas = ApplicationQuota(None, None, None)
     sleep(1)
     assert quotas.allow_send({'application': 'testapp'})
     assert quotas.allow_send({'application': 'testapp'})


### PR DESCRIPTION
- Fix bug where app-specific metrics disappear frequently

- Fix bug where the sync targets script doesn't emit metrics except for
  just once on start

- Move custom methods to set metric info out of bin/sender

- Use `incr`/`set` methods instead of accessing the raw dict directly. Makes
   us handle metrics closer to how other metrics libraries do

- Avoid using a single method to initialize and then set a metric for
  clarity

- Make the default sender config use "dummy" instead of influxdb, so
  we can see what metrics are emitted

- Tidy the metrics output of the dummy metrics emitter