### PR TITLE
Make the ldap_count metric from sync-targets not get reset

### DIFF
--- a/src/iris_api/bin/sync_targets.py
+++ b/src/iris_api/bin/sync_targets.py
@@ -28,7 +28,6 @@ logging.getLogger('requests').setLevel(logging.WARNING)
 
 
 stats_reset = {
-    'ldap_found': 0,
     'sql_errors': 0,
     'users_added': 0,
     'users_failed_to_add': 0,
@@ -318,6 +317,10 @@ def main():
 
     engine = create_engine(config['db']['conn']['str'] % config['db']['conn']['kwargs'],
                            **config['db']['kwargs'])
+
+    # Initialize this to zero at the start of the app, and don't reset it at every
+    # metrics interval
+    metrics.set('ldap_found', 0)
 
     metrics_task = spawn(metrics.emit_forever)
 


### PR DESCRIPTION
Currently, the ldap_count metric will be emitted as non-zero once
every hour during the sync() loop, and then it will be reset back
to zero.

Instead of that, initially emit the metric as zero, and after that
continually emit the last value we received. This will make looking
at graphs easier to clean changes in the employee count over time.

This is also the old behavior that disappeared several months back.