### PR TITLE
Add filtering support to the stats/app stats endpoints

### DIFF
--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -2426,11 +2426,16 @@ class Stats(object):
 
         stats = {}
 
+        fields_filter = req.get_param_as_list('fields')
+        fields = queries.viewkeys()
+        if fields_filter:
+            fields &= set(fields_filter)
+
         connection = db.engine.raw_connection()
         cursor = connection.cursor()
-        for key, query in queries.iteritems():
+        for key in fields:
             start = time.time()
-            cursor.execute(query)
+            cursor.execute(queries[key])
             result = cursor.fetchone()
             if result:
                 result = result[-1]
@@ -2528,11 +2533,16 @@ class ApplicationStats(object):
 
         stats = {}
 
+        fields_filter = req.get_param_as_list('fields')
+        fields = queries.viewkeys()
+        if fields_filter:
+            fields &= set(fields_filter)
+
         connection = db.engine.raw_connection()
         cursor = connection.cursor()
-        for key, query in queries.iteritems():
+        for key in fields:
             start = time.time()
-            cursor.execute(query, query_data)
+            cursor.execute(queries[key], query_data)
             result = cursor.fetchone()
             if result:
                 result = result[-1]

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1666,6 +1666,14 @@ def test_stats():
         assert key in data
         assert isinstance(data[key], int) or isinstance(data[key], float)
 
+    re = requests.get(base_url + 'stats?fields=total_active_users&fields=total_plans')
+    assert re.status_code == 200
+    assert re.json().viewkeys() == {'total_active_users', 'total_plans'}
+
+    re = requests.get(base_url + 'stats?fields=fakefield')
+    assert re.status_code == 200
+    assert re.json() == {}
+
 
 def test_app_stats(sample_application_name):
     re = requests.get(base_url + 'applications/sfsdf232423fakeappname/stats')
@@ -1679,6 +1687,14 @@ def test_app_stats(sample_application_name):
                 'pct_successful_twilio_sms_last_month', 'pct_successful_twilio_call_last_month'):
         assert key in data
         assert isinstance(data[key], int) or isinstance(data[key], float)
+
+    re = requests.get(base_url + 'applications/%s/stats?fields=total_messages_sent_today&fields=total_incidents_today' % sample_application_name)
+    assert re.status_code == 200
+    assert re.json().viewkeys() == {'total_messages_sent_today', 'total_incidents_today'}
+
+    re = requests.get(base_url + 'applications/%s/stats?fields=fakefield' % sample_application_name)
+    assert re.status_code == 200
+    assert re.json() == {}
 
 
 def test_post_notification(sample_user, sample_application_name):


### PR DESCRIPTION
Some of those queries take a really long time whereas some don't;
allow the user to optionally specify which they actuall want.