### PR TITLE
User sync targets tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setuptools.setup(
         'streql==3.0.2',
         'dnspython==1.14.0',
         'phonenumbers==7.4.1',
-        'python-ldap==2.4.9',
         'twilio==4.5.0',
         'google-api-python-client==1.4.2',
         'oauth2client==1.4.12',


### PR DESCRIPTION
- Instead of pulling from ldap directly, pull from the calendar's database'
  API endpoints. It is now the source of truth for what users exist.

- Abstract away api calls into separate functions so they can be mocked during
  testing

- Bail if the oncall URL is not present in config

- Rename references from ldap to oncall to more accurately express where the
  users are coming from

- Add metric for the number of teams found