### PR TITLE
Avoid hard coding default route in various places

### DIFF
--- a/src/iris_api/api.py
+++ b/src/iris_api/api.py
@@ -743,7 +743,7 @@ class ACLMiddleware(object):
         if req.context['username']:
             # Logged in and looking at /login page? Redirect to home.
             if req.path == '/login':
-                raise HTTPFound('/')
+                raise HTTPFound(ui.default_route)
         else:
             # If we're not logged in and this is a frontend route, we're only allowed
             # to view the login form

--- a/src/iris_api/ui/__init__.py
+++ b/src/iris_api/ui/__init__.py
@@ -48,6 +48,11 @@ def hms(seconds):
 jinja2_env.filters['hms'] = hms
 
 
+default_route = '/incidents'
+
+
+jinja2_env.globals['default_route'] = default_route
+
 def login_url(req):
     if req.path and req.path != '/login' and req.path != '/logout' and req.path != '/':
         return '/login/?next=%s' % uri.encode_value(req.path)
@@ -105,7 +110,7 @@ class Index(object):
     frontend_route = True
 
     def on_get(self, req, resp):
-        raise HTTPFound('/incidents')
+        raise HTTPFound(default_route)
 
 
 class Stats(object):
@@ -256,7 +261,7 @@ class Login():
         url = req.get_param('next')
 
         if not url or url.startswith('/'):
-            raise HTTPFound(url or '/incidents')
+            raise HTTPFound(url or default_route)
         else:
             raise HTTPBadRequest('Invalid next parameter', '')
 

--- a/src/iris_api/ui/templates/base.html
+++ b/src/iris_api/ui/templates/base.html
@@ -24,7 +24,7 @@
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="/"><span><img id="logo" src="/static/images/iris.png"></span><span>IRIS</span></a>
+            <a class="navbar-brand" href="{{ default_route }}"><span><img id="logo" src="/static/images/iris.png"></span><span>IRIS</span></a>
 
           </div>
           <div id="navbar" class="navbar-collapse collapse">

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1999,7 +1999,7 @@ def test_ui_routes(sample_user, sample_admin_user):
     # And login redirects to home page
     re = requests.get(ui_url + 'login', allow_redirects=False, headers=username_header(sample_user))
     assert re.status_code == 302
-    assert re.headers['Location'] == '/'
+    assert re.headers['Location'] == '/incidents'
 
     # Test actual login + logout session using beaker's cookies in requests session, rather than using the header trick:
     session = requests.Session()


### PR DESCRIPTION
- The default home-page is the incidents page, but make this easier
  to change in the future if needed, by defining it in one spot.

- Also avoid redirects from / to /incidents which can be avoided by going to /incidents off the bat