### PR TITLE
Track successful message sending for email

### DIFF
--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -652,6 +652,18 @@ CREATE TABLE `incident_emails` (
   CONSTRAINT `incident_emails_plan_name_ibfk` FOREIGN KEY (`plan_name`) REFERENCES `plan_active` (`name`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+--
+-- Table structure for table `generic_message_sent_status`
+--
+
+DROP TABLE IF EXISTS `generic_message_sent_status`;
+CREATE TABLE `generic_message_sent_status` (
+  `message_id` bigint(20) NOT NULL,
+  `status` tinyint(1) NOT NULL,
+  PRIMARY KEY (`message_id`),
+  CONSTRAINT `generic_message_sent_status_message_id_ibfk` FOREIGN KEY (`message_id`) REFERENCES `message` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/src/iris_api/ui/static/js/iris.js
+++ b/src/iris_api/ui/static/js/iris.js
@@ -1443,6 +1443,9 @@ iris = {
           template = this.data.template = Handlebars.compile(this.data.incidentSource),
           template_vars = {changes: []};
       $.getJSON(self.data.url + path).done(function(data) {
+          if (data.generic_message_sent_status != null) {
+              data.generic_message_sent_status = data.generic_message_sent_status ? 'sent' : 'failed to send';
+          }
           $.extend(template_vars, data);
           $.getJSON(self.data.url + path + '/auditlog').done(function(data) {
             data.forEach(function(change) {

--- a/src/iris_api/ui/templates/message.html
+++ b/src/iris_api/ui/templates/message.html
@@ -82,6 +82,12 @@
       <p>
         <label><strong>Twilio Delivery Status:</strong></label> {{ twilio_delivery_status }}
       </p>
+      {{else}}
+        {{#if generic_message_sent_status }}
+        <p>
+          <label><strong>Status:</strong></label> {{ generic_message_sent_status }}
+        </p>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1696,7 +1696,7 @@ def test_app_stats(sample_application_name):
                 'pct_incidents_claimed_last_month', 'median_seconds_to_claim_last_month',
                 'pct_successful_twilio_sms_last_month', 'pct_successful_twilio_call_last_month',
                 'total_incidents_last_month', 'total_messages_sent_last_month',
-                'pct_failed_twilio_call_last_month'):
+                'pct_failed_twilio_call_last_month', 'pct_successful_email_last_month'):
         assert data[key] is None or isinstance(data[key], int) or isinstance(data[key], float)
 
     re = requests.get(base_url + 'applications/%s/stats?fields=total_messages_sent_today&fields=total_incidents_today' % sample_application_name)


### PR DESCRIPTION
- Base it off of smtp success vs failure
- Make additional table because we can't use the twilio specific one
- Show status in UI as well
- Add it to the application stats endpoint as an additional percentage
  for the same window as the other statistics