### PR TITLE
Docker fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN chown -R iris:iris /home/iris /var/log/nginx /var/lib/nginx \
 
 EXPOSE 16649
 
-CMD ["bash", "-c", "source /home/iris/env/bin/activate && python /home/iris/entrypoint.py"]
+CMD ["sudo", "-Hu", "iris", "bash", "-c", "source /home/iris/env/bin/activate && python /home/iris/entrypoint.py"]

--- a/docker/config/config.yaml
+++ b/docker/config/config.yaml
@@ -1,11 +1,15 @@
 server:
   disable_auth: True
 
-# This will soon be replaced with a ldap module bundled with iris-api
-role_lookup:
+role_lookup: dummy
+metrics: dummy
 
-metrics: prometheus
+# Change these to random long values when you run this in production
+user_session:
+  encrypt_key: 'abc'
+  sign_key: '123'
 
+#metrics: prometheus
 #prometheus:
 #  iris-sync-targets:
 #    server_port: 8001
@@ -27,8 +31,8 @@ db: &db
       scheme: mysql+pymysql
 
       # fill these in:
-      user:
-      password:
+      user: iris
+      password: iris
       host:
       database: iris
       charset: utf8


### PR DESCRIPTION
- Run the entrypoint as the "iris" user to avoid egg extraction errors to
  /root (probably because the $HOME env variable never gets changed,
  despite uwsgi setuid'ing)

- Include newly required config keys, make prometheus commented out
   as it's normally not needed.