### PR TITLE
Disable "show key" button when you click it

### DIFF
--- a/src/iris_api/ui/static/js/iris.js
+++ b/src/iris_api/ui/static/js/iris.js
@@ -1927,6 +1927,7 @@ iris = {
     },
     showApiKey: function() {
       var self = this;
+      $(self.data.showApiKeyButton).prop('disabled', true);
       $.get('/v0/applications/' + self.data.application + '/key').done(function(result) {
         self.data.model.apiKey = result.key;
         self.modelPersist();


### PR DESCRIPTION
Loading the key takes around a second when run in real life, so leaving
the button clickable after you click it is unclean.

(This isn't noticeable when running iris locally)