### PR TITLE
Create app UI + app tweaks

### DIFF
--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -35,7 +35,8 @@ CREATE TABLE `application` (
   `auth_only` tinyint(1) DEFAULT '0',
   `allow_other_app_incidents` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `allow_authenticating_users` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name_idx` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/src/iris/ui/static/css/iris.css
+++ b/src/iris/ui/static/css/iris.css
@@ -974,6 +974,10 @@ table.dataTable thead .sorting_asc {
   height: 22px;
 }
 
+#show-app-modal-button {
+  margin-top: -5px;
+}
+
 .template-notification textarea {
   height: 250px;
 }

--- a/src/iris/ui/templates/applications.html
+++ b/src/iris/ui/templates/applications.html
@@ -1,7 +1,29 @@
 {% extends "base.html" %}
 {% block content %}
 <div class="main applications">
-  <h3>Applications</h3>
+  <!-- Modal for a new application -->
+  <div class="modal fade" id="create-app-modal" tabindex="-1" role="dialog" aria-labelledby="show-app-modal-button">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title">Create Application</h4>
+        </div>
+        <div class="modal-body">
+          This will create a new Iris application.
+          <div class="form-inline">
+            <label for="create-app-name">Application Name: </label>
+            <input type="text" class="form-control input-sm typeahead" data-targettype="user" placeholder="Application" id="create-app-name"></input>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary btn-sm" id="create-app-submit">Create App</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <h3><!-- h3 template with app create button gets rendered here --></h3>
   <div class="module">
     <table class="display" id="applications-table" width="100%">
       <!-- applications table renders here -->
@@ -25,6 +47,11 @@
     {{/each}}
   </tbody>
 </script>
+<script id="applications-header-template" type="text/x-handlebars-application">
+  Applications
+  {{# if @root.showCreateButton }}
+    <button id="show-app-modal-button" class="btn btn-primary btn-sm pull-right">Create Application</button>
+  {{/if}}
+</script>
 {% endraw %}
 {% endblock %}
-


### PR DESCRIPTION
- Add UI to create applications

- Make /v0/applications/$name support creating applications if you're an admin
  and if the app does not exist and if a do_create flag is passed. Add test
  for this.

- Make the `application`.`name` field unique to enforce integrity

- Make the app viewing page treat the application name as case insensitve,
  as they are.