### PR TITLE
Refactor loading of configs

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -529,7 +529,15 @@ def load_config_file(path=None):
 
 
 def load_config(path=None):
-    ''' Process both config file (which might be monkey patched) as well as any config hooks '''
+    '''
+      Generate configs for iris. This first calls load_config_file, which
+      will read configs from a yaml file. It will then pass that through
+      process_config_hook() which looks for a key called init_config_hook
+      which is the name of a module to call which can tweak the config further.
+
+      load_config_file() can be monkey patched, in which case this config
+      loading functionality can be customized further.
+    '''
     return process_config_hook(load_config_file(path))
 
 

--- a/src/iris/bin/run_server.py
+++ b/src/iris/bin/run_server.py
@@ -56,15 +56,11 @@ def sigint_handler(sig, frame):
 
 
 def main():
-    if len(sys.argv) < 2:
-        print 'Usage: %s CONFIG_FILE' % sys.argv[0]
-        sys.exit(1)
-
     signal.signal(signal.SIGINT, sigint_handler)
 
-    from iris.api import get_api, load_config_file
+    from iris.api import get_api, load_config
 
-    config = load_config_file(sys.argv[1])
+    config = load_config()
     app = get_api(config)
 
     server = config['server']

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -5,7 +5,6 @@ from gevent import monkey, sleep, spawn, queue
 monkey.patch_all()  # NOQA
 
 import logging
-import sys
 import time
 import ujson
 
@@ -17,7 +16,7 @@ from iris import metrics
 from uuid import uuid4
 from iris.gmail import Gmail
 from iris import db
-from iris.api import load_config_file
+from iris.api import load_config
 from iris.sender import rpc, cache
 from iris.sender.message import update_message_mode
 from iris.sender.oneclick import oneclick_email_markup, generate_oneclick_url
@@ -1003,13 +1002,9 @@ def init_sender(config):
 
 
 def main():
-    if len(sys.argv) <= 1:
-        print 'ERROR: missing config file.'
-        print 'usage: %s API_CONFIG_FILE' % sys.argv[0]
-        sys.exit(1)
 
     global config
-    config = load_config_file(sys.argv[1])
+    config = load_config()
 
     is_master = config['sender'].get('is_master', False)
     logger.info('[-] bootstraping sender (master: %s)...', is_master)

--- a/src/iris/bin/sync_targets.py
+++ b/src/iris/bin/sync_targets.py
@@ -4,7 +4,6 @@
 from gevent import monkey, sleep, spawn
 monkey.patch_all()  # NOQA
 
-import sys
 import logging
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -13,7 +12,7 @@ import requests
 from phonenumbers import format_number, parse, PhoneNumberFormat
 from phonenumbers.phonenumberutil import NumberParseException
 
-from iris.api import load_config_file
+from iris.api import load_config
 from iris import metrics
 
 from requests.packages.urllib3.exceptions import (
@@ -262,7 +261,7 @@ def sync(config, engine, purge_old_users=True):
 
 
 def main():
-    config = load_config_file(sys.argv[1])
+    config = load_config()
     metrics.init(config, 'iris-sync-targets', stats_reset)
 
     default_nap_time = 3600

--- a/src/iris/wrappers/gunicorn.py
+++ b/src/iris/wrappers/gunicorn.py
@@ -1,3 +1,3 @@
 import os
-from iris.api import load_config_file, get_api
-application = get_api(load_config_file(os.environ['CONFIG']))
+from iris.api import load_config, get_api
+application = get_api(load_config(os.environ['CONFIG']))


### PR DESCRIPTION
- Make the config loader be a single function in iris.api which can
  be easily monkey patched by other systems embedding iris, while
  also incorporating functionality for use with the config hooks