### PR TITLE
Add support for log files sync-targets and sender daemons

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -7,6 +7,7 @@ monkey.patch_all()  # NOQA
 import logging
 import time
 import ujson
+import os
 
 from collections import defaultdict
 from iris.plugins import init_plugins
@@ -167,10 +168,13 @@ WHERE `id`=%s'''
 PRUNE_OLD_AUDIT_LOGS_SQL = '''DELETE FROM `message_changelog` WHERE `date` < DATE_SUB(CURDATE(), INTERVAL 3 MONTH)'''
 
 # logging
-
 logger = logging.getLogger()
 formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s')
-ch = logging.StreamHandler()
+log_file = os.environ.get('SENDER_LOG_FILE')
+if log_file:
+    ch = logging.handlers.RotatingFileHandler(log_file, mode='a', maxBytes=10485760, backupCount=10)
+else:
+    ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)
 ch.setFormatter(formatter)
 logger.setLevel(logging.INFO)

--- a/src/iris/bin/sync_targets.py
+++ b/src/iris/bin/sync_targets.py
@@ -5,6 +5,7 @@ from gevent import monkey, sleep, spawn
 monkey.patch_all()  # NOQA
 
 import logging
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
@@ -35,9 +36,14 @@ stats_reset = {
     'user_contacts_updated': 0,
 }
 
+# logging
 logger = logging.getLogger()
 formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s')
-ch = logging.StreamHandler()
+log_file = os.environ.get('SYNC_TARGETS_LOG_FILE')
+if log_file:
+    ch = logging.handlers.RotatingFileHandler(log_file, mode='a', maxBytes=10485760, backupCount=10)
+else:
+    ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)
 ch.setFormatter(formatter)
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
Support logging to files instead of just standard out.

Use the rotating log handler to avoid infinitely growing files filling
disk, but provide more storage duration (100MB) compared to some alternatives.

Make path to log configurable from the environment vars, useful for
when they're running under uwsgi.